### PR TITLE
Added apache__redirect_to_https variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ debops.apache v0.1.0 - unreleased
 Added
 ~~~~~
 
+- Add :envvar:`apache__redirect_to_https` to control the role's default behaviour for
+  redirecting to https. [muelli_]
+
 - Initial coding and design. [ypid_]
 
 - Add/Set the default `Referrer Policy`_ to ``no-referrer`` and made it

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,14 +465,14 @@ apache__combined_snippets: '{{ apache__dependent_snippets
 apache__https_enabled: '{{ ansible_local|d() and ansible_local.pki|d() and
                            (ansible_local.pki.enabled|d() | bool) and
                            apache__https_listen|length > 0 }}'
+
                                                                    # ]]]
-
-
 # .. envvar:: apache__redirect_to_https [[[
 #
 # This defines the default for each vhost's ``redirect_to_https`` variable.
 # Defaults to ``True``.
 apache__redirect_to_https: True
+
                                                                    # ]]]
 # PKI [[[
 # ~~~~~~~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,7 +465,14 @@ apache__combined_snippets: '{{ apache__dependent_snippets
 apache__https_enabled: '{{ ansible_local|d() and ansible_local.pki|d() and
                            (ansible_local.pki.enabled|d() | bool) and
                            apache__https_listen|length > 0 }}'
+                                                                   # ]]]
 
+
+# .. envvar:: apache__redirect_to_https [[[
+#
+# This defines the default for each vhost's ``redirect_to_https`` variable.
+# Defaults to ``True``.
+apache__redirect_to_https: True
                                                                    # ]]]
 # PKI [[[
 # ~~~~~~~

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -328,7 +328,7 @@ Refer to the `Apache Redirect directive documentation`_ for details.
   HTTPS, by default 301 Moved Permanently.
 
 ``redirect_to_https``
-  Optional, boolean. Defaults to ``True``
+  Optional, boolean. Defaults to ``apache__redirect_to_https``
   If ``True``, redirect connection from HTTP to the HTTPS version of the site.
   Set to ``False`` to allow to serve the website via HTTP and HTTPS and don't
   redirect HTTP to HTTPS.

--- a/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -255,7 +255,7 @@ Header {{ apache__tpl_directive_options }} X-Content-Type-Options "{{ item.http_
 {% macro get_common_headers(item) %}{# [[[ #}
 {% if item.http_clacks_overhead|d(apache__http_clacks_overhead|d(True)) | bool %}
 {#
-# Respect the will of the DebOps Creater.
+# Respect the will of the DebOps Creator.
 # Ref: https://github.com/debops/ansible-nginx/commit/d6cd455c68a7584b2592053fd98d3e539054e09a
 #}
 Header always set X-Clacks-Overhead "GNU Terry Pratchett"

--- a/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -127,7 +127,7 @@ ErrorLog ${APACHE_LOG_DIR}/{{ sanitized_name }}_error.log
 {% set apache__tpl_status_enabled = item.status_enabled|d(apache__status_for_vhost_enabled) | bool %}
 {{ get_server_status_directives(item, apache__tpl_status_enabled) -}}
 {% if apache__tpl_status_enabled|bool and (
-        (mode == 'http' and (item.redirect_http|d() or item.redirect_to_https|d(https_enabled) | bool)) or
+        (mode == 'http' and (item.redirect_http|d() or item.redirect_to_https|d(apache__redirect_to_https) | bool)) or
         (mode == 'https' and item.redirect_https|d())
     ) %}
 RewriteEngine On
@@ -136,7 +136,7 @@ RewriteRule "^{{ item.status_location|d(apache__status_location) }}" "-" [L]
 {% endif %}
 {% if mode == 'http' and item.redirect_http|d() %}
 {{ get_redirect(item.redirect_http_code|d(307), "/", item.redirect_http, apache__tpl_use_redirect_module) }}
-{% elif mode == 'http' and item.redirect_to_https|d(https_enabled) | bool %}
+{% elif mode == 'http' and item.redirect_to_https|d(apache__redirect_to_https) | bool %}
 {{ get_redirect(item.redirect_to_https_with_code|d("301"), "/", "https://" + (debops__tpl_macros.get_yaml_list_for_elem(item.name) | from_yaml)[0], apache__tpl_use_redirect_module) }}
 {% elif mode == 'https' and item.redirect_https|d() %}
 {{ get_redirect(item.redirect_https_code|d(307), "/", item.redirect_https, apache__tpl_use_redirect_module) }}


### PR DESCRIPTION
Currently, each vhost can define "redirect_to_https".  If True, which is
the current default, then the Apache configuration will include a
Redirect line.

This is good, except that VirtualHost rules seem to have precedence over
other rules.  That is annoying when you want to define a global rule to
serve, say, ACME requests, because Apache would respect the VirtualHost
rules and redirect the plain HTTP request instead of serving the token.
To help debops users to not having to touch each and every defined
vhost, the new variable defines the default value for redirect_to_https,
which used to be "True".  The default is still "True", but now you can
override that easily.