### PR TITLE
Do not https_redirect 000-default vhost

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -652,6 +652,7 @@ apache__vhosts: []
 apache__default_vhost:
   name: '000-default'
   root: '/var/www/html'
+  redirect_to_https: False
 
                                                                    # ]]]
 # .. envvar:: apache__group_vhosts [[[


### PR DESCRIPTION
The problem is that the currently generated default Redirect line takes
the "name" as redirection target.  The name, in this default case, is
"000-default", so Apache would redirect to https://000-default/ which is
nonsensical.

By setting redirect_to_https to False the redirection won't be
established.