### PR TITLE
Add Content-Security-Policy support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,10 +17,10 @@ debops.apache v0.1.0 - unreleased
 Added
 ~~~~~
 
+- Initial coding and design. [ypid_]
+
 - Add :envvar:`apache__redirect_to_https` to control the role's default behaviour for
   redirecting to https. [muelli_]
-
-- Initial coding and design. [ypid_]
 
 - Add/Set the default `Referrer Policy`_ to ``no-referrer`` and made it
   configurable via :ref:`item.http_referrer_policy <apache__ref_vhost_http_referrer_policy>`.
@@ -40,6 +40,10 @@ Added
 
 - Add Ansible tags for env roles. To only prepare the Apache role
   environment, you can use the ``role::apache:env`` tag. [ypid_]
+
+- Support to set the HTTP headers ``Content-Security-Policy`` and
+  ``Content-Security-Policy-Report-Only``.
+  Refer to :ref:`apache__ref_servers_http_security_headers` for details. [ypid_]
 
 Changed
 ~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,9 +22,13 @@ Added
 - Add :envvar:`apache__redirect_to_https` to control the role's default behaviour for
   redirecting to https. [muelli_]
 
-- Add/Set the default `Referrer Policy`_ to ``no-referrer`` and made it
+- Add/Set the default `Referrer Policy`_ to ``same-origin`` and made it
   configurable via :ref:`item.http_referrer_policy <apache__ref_vhost_http_referrer_policy>`.
-  [ypid_]
+
+  Note that ``no-referrer`` was originally used in an unreleased version of the
+  role but this seemed to cause issues with certain applications so it was
+  changed to ``same-origin`` by default. ``no-referrer`` can still be used when
+  you know it does not break anything. [ypid_, drybjed_, scibi_]
 
 - Add the :envvar:`apache__mpm_max_connections_per_child` variable to allow to
   configure the number of requests a child process should handle before

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -730,7 +730,7 @@ apache__http_xss_protection: '1; mode=block'
 # .. envvar:: apache__http_referrer_policy [[[
 #
 # Refer to :ref:`item.http_referrer_policy <apache__ref_vhost_http_referrer_policy>` for details.
-apache__http_referrer_policy: 'no-referrer'
+apache__http_referrer_policy: 'same-origin'
 
                                                                    # ]]]
 # .. envvar:: apache__http_content_type_options [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -704,6 +704,15 @@ apache__hsts_preload: False
 # have to be fine-tuned for the website in question.
 # Refer :ref:`apache__ref_servers_http_security_headers` for details.
 
+# .. envvar:: apache__http_csp_append [[[
+#
+# CSP directives to append to all policies. This can be used to set the
+# ``report-uri`` globally.
+# The string MUST end with a semicolon but MUST NOT begin with one.
+# Refer :ref:`apache__ref_servers_http_security_headers` for details.
+apache__http_csp_append: ''
+
+                                                                   # ]]]
 # .. envvar:: apache__http_frame_options [[[
 #
 # Default value for the ``X-Frame-Options`` header. Set to ``False`` to omit

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -397,6 +397,7 @@ HTTP security headers
   Optional, string. Defaults to: ``default-src https: ;`` (force all assets to be loaded over HTTPS).
   Sets the first part of the ``Content-Security-Policy`` header.
   The string MUST end with a semicolon but MUST NOT begin with one.
+  Make sure that you only use single quotes and no double quotes in the string.
   If no ``item.csp_report`` is given, it also determines the first part of the
   ``Content-Security-Policy-Report-Only`` header.
   Which headers are actually enabled is defined by ``item.csp_enabled``

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -394,23 +394,34 @@ HTTP security headers
 ~~~~~~~~~~~~~~~~~~~~~
 
 ``csp``
-  Optional, boolean. Defaults to ``False``.
-  If set to ``True`` and HTTPS is enabled for this item, the
-  Content-Security-Policy header is set in server responses. If this is set to
-  ``False``, the Content-Security-Policy header will not be set.
+  Optional, string. Defaults to: ``default-src https: ;`` (force all assets to be loaded over HTTPS).
+  Sets the first part of the ``Content-Security-Policy`` header.
+  The string MUST end with a semicolon but MUST NOT begin with one.
+  If no ``item.csp_report`` is given, it also determines the first part of the
+  ``Content-Security-Policy-Report-Only`` header.
+  Which headers are actually enabled is defined by ``item.csp_enabled``
+  and ``item.csp_report_enabled``.
+  Refer to the `Content Security Policy Reference`_.
 
 ``csp_report``
+  Optional, string. This allows to set a different/potentially experimental
+  ``Content-Security-Policy-Report-Only`` header than defined by ``item.csp``.
+
+``csp_append``
+  Optional, string. Defaults to: :envvar:`apache__http_csp_append`.
+  CSP directives to append to all policies (``item.csp`` and ``item.csp_report``).
+  This can be used to overwrite the default :envvar:`apache__http_csp_append` as needed.
+  The string MUST end with a semicolon but MUST NOT begin with one.
+
+``csp_enabled``
+  Optional, boolean. Defaults to ``False``.
+  If set to ``True`` and HTTPS is enabled for this item, the
+  ``Content-Security-Policy`` header is set in server responses.
+
+``csp_report_enabled``
   Optional, boolean. Defaults to ``False``.
   If this is set to ``True`` and HTTPS is enabled for this item, the
-  Content-Security-Policy-Report-Only header is set in the server responses.
-  If this is set to ``False``, the Content-Security-Policy-Report-Only header
-  will not be set in the server's responses.
-
-``csp_policy``
-  Optional, string. Defaults to: ``default-src https:`` (force all assets to be loaded over HTTPS).
-  If ``item.csp`` or ``item.csp_report`` option is ``True``, this option
-  determines the Content-Security-Policy header set in server responses.
-  Refer to the `Content Security Policy Reference`_.
+  ``Content-Security-Policy-Report-Only`` header is set in the server responses.
 
 .. _apache__ref_vhost_http_xss_protection:
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -37,6 +37,11 @@ configuration is already in the desired state.
 
 Available role tags:
 
+``role::apache:env``
+  Environment role tag, should be used in the playbook to execute a special
+  environment role contained in the main role. The environment role prepares
+  the environment for other dependency roles to work correctly.
+
 ``role::apache``
   Main role tag, should be used in the playbook to execute all of the role
   tasks as well as role dependencies.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -10,8 +10,8 @@ Getting started
 Example inventory
 -----------------
 
-To manage Apache on a given host it should be included in the
-``debops_service_apache`` Ansible inventory group:
+To manage Apache on a given host or set of hosts, they need to be added
+to the ``[debops_service_apache]`` Ansible group in the inventory:
 
 .. code:: ini
 

--- a/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -239,10 +239,10 @@ Header always set Strict-Transport-Security "max-age={{ item.hsts_max_age|d(apac
 {% macro get_http_security_headers(item) %}{# [[[ #}
 {% set apache__tpl_directive_options = debops__tpl_macros.get_yaml_list_for_elem(item.http_sec_headers_directive_options|d(apache__http_sec_headers_directive_options)) | from_yaml | map("quote") | join(" ") %}
 {% if item.csp_enabled|d(False) | bool %}
-Header {{ apache__tpl_directive_options }} Content-Security-Policy "{{ item.csp|d("default-src https: ;") + item.csp_append|d(apache__http_csp_append) }}"
+Header {{ apache__tpl_directive_options }} Content-Security-Policy "{{ item.csp|d("default-src https: ;") + (" " + item.csp_append|d(apache__http_csp_append) if (item.csp_append|d(apache__http_csp_append)) else "") }}"
 {% endif %}
 {% if item.csp_report_enabled|d(False) | bool %}
-Header {{ apache__tpl_directive_options }} Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + item.csp_append|d(apache__http_csp_append) }}"
+Header {{ apache__tpl_directive_options }} Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + (" " + item.csp_append|d(apache__http_csp_append) if (item.csp_append|d(apache__http_csp_append)) else "") }}"
 {% endif %}
 {% if apache__http_frame_options|d(item.http_frame_options) %}
 Header {{ apache__tpl_directive_options }} X-Frame-Options "{{ apache__http_frame_options|d(item.http_frame_options) }}"

--- a/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -238,6 +238,12 @@ Header always set Strict-Transport-Security "max-age={{ item.hsts_max_age|d(apac
 
 {% macro get_http_security_headers(item) %}{# [[[ #}
 {% set apache__tpl_directive_options = debops__tpl_macros.get_yaml_list_for_elem(item.http_sec_headers_directive_options|d(apache__http_sec_headers_directive_options)) | from_yaml | map("quote") | join(" ") %}
+{% if item.csp_enabled|d(False) | bool %}
+Header {{ apache__tpl_directive_options }} Content-Security-Policy "{{ item.csp|d("default-src https: ;") + item.csp_append|d(apache__http_csp_append) }}"
+{% endif %}
+{% if item.csp_report_enabled|d(False) | bool %}
+Header {{ apache__tpl_directive_options }} Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + item.csp_append|d(apache__http_csp_append) }}"
+{% endif %}
 {% if apache__http_frame_options|d(item.http_frame_options) %}
 Header {{ apache__tpl_directive_options }} X-Frame-Options "{{ apache__http_frame_options|d(item.http_frame_options) }}"
 {% endif %}


### PR DESCRIPTION
Currently work in progress/untested. Reworks/is based on the design in debops.nginx from https://github.com/debops/ansible-nginx/pull/118.

Additional review requested from: @carlalexander