### PR TITLE
Disable snippets before touching modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,10 +36,11 @@
     force: '{{ ansible_check_mode|d() | bool }}'
     state: 'absent'
   when: (item.value.type|d("default") not in ["divert"]) and
-        ((not (item.value.enabled|d(True)
+        ((item.value.state|d("present") == "absent") or
+         (not (item.value.enabled|d(True)
                if (item.value is mapping)
-               else item.value|d(True))) or
-         (item.value.state|d("present") == "absent"))
+               else item.value|d(True))))
+
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
 
@@ -79,10 +80,11 @@
     force: '{{ ansible_check_mode|d() | bool }}'
     state: 'link'
   when: (item.value.type|d("default") not in ["divert"]) and
+        (item.value.state|d("present") != "absent") and
         ((item.value.enabled|d(True)
           if (item.value is mapping)
-          else item.value|d(True)) or
-         (item.value.state|d("present") != "absent"))
+          else item.value|d(True)))
+
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,21 +27,22 @@
   args:
     creates: '{{ ( item.value.divert | d(apache__config_path + "/conf-available/" + (item.value.divert_filename|d(item.key)) + ".conf"))
                  + item.value.divert_suffix|d(".dpkg-divert") }}'
+  register: apache__register_conf_diverted
   when: (item.value.type|d("default") in ["divert"])
   with_dict: '{{ apache__combined_snippets }}'
 
 - name: Disable configuration snippets
   file:
-    path: '{{ apache__config_path + "/conf-enabled/" + item.key + ".conf" }}'
+    path: '{{ apache__config_path + "/conf-enabled/" + item.item.key + ".conf" }}'
     force: '{{ ansible_check_mode|d() | bool }}'
     state: 'absent'
-  when: (item.value.type|d("default") not in ["divert"]) and
-        ((item.value.state|d("present") == "absent") or
-         (not (item.value.enabled|d(True)
-               if (item.value is mapping)
-               else item.value|d(True))))
-
-  with_dict: '{{ apache__combined_snippets }}'
+  when: ((item.item.value.type|d("default") == "divert") and
+         (item | changed)) or
+        ((item.item.value.state|d("present") == "absent") or
+         (not (item.item.value.enabled|d(True)
+               if (item.item.value is mapping)
+               else item.item.value|d(True))))
+  with_items: '{{ apache__register_conf_diverted.results }}'
   notify: [ 'Test apache and reload' ]
 
 # Manage Apache modules [[[1
@@ -84,10 +85,8 @@
         ((item.value.enabled|d(True)
           if (item.value is mapping)
           else item.value|d(True)))
-
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
-
 
 # Manage Apache virtual hosts [[[1
 - name: Divert sites-available configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,13 +33,13 @@
 - name: Disable configuration snippets
   file:
     path: '{{ apache__config_path + "/conf-enabled/" + item.key + ".conf" }}'
-    src: '../conf-available/{{ item.key }}.conf'
     force: '{{ ansible_check_mode|d() | bool }}'
     state: 'absent'
-  when: (not (item.value.enabled|d(True)
-              if (item.value is mapping)
-              else item.value|d(True))) or
-        (item.value.state|d("present") == "absent")
+  when: (item.value.type|d("default") not in ["divert"]) and
+        ((not (item.value.enabled|d(True)
+               if (item.value is mapping)
+               else item.value|d(True))) or
+         (item.value.state|d("present") == "absent"))
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
 
@@ -77,7 +77,7 @@
     path: '{{ apache__config_path + "/conf-enabled/" + item.key + ".conf" }}'
     src: '../conf-available/{{ item.key }}.conf'
     force: '{{ ansible_check_mode|d() | bool }}'
-    state: 'present'
+    state: 'link'
   when: (item.value.type|d("default") not in ["divert"]) and
         ((item.value.enabled|d(True)
           if (item.value is mapping)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,39 @@
     - '{{ apache__packages }}'
     - '{{ apache__dependent_packages }}'
 
+# Remove/disable Apache configuration snippets [[[1
+- name: Remove conf-available snippets
+  file:
+    path: '{{ apache__config_path + "/conf-available/" + item.key + ".conf" }}'
+    state: 'absent'
+  when: (item.value.state|d("present") == "absent")
+  with_dict: '{{ apache__combined_snippets }}'
+  tags: [ 'role::apache:vhosts' ]
+
+- name: Divert conf-available configuration
+  command: dpkg-divert --quiet --local
+             --divert {{ ((item.value.divert | d(apache__config_path + "/conf-available/" + (item.value.divert_filename|d(item.key)) + ".conf"))
+                         + item.value.divert_suffix|d(".dpkg-divert")) | quote }}
+             --rename {{ (apache__config_path + "/conf-available/" + item.key + ".conf") | quote }}
+  args:
+    creates: '{{ ( item.value.divert | d(apache__config_path + "/conf-available/" + (item.value.divert_filename|d(item.key)) + ".conf"))
+                 + item.value.divert_suffix|d(".dpkg-divert") }}'
+  when: (item.value.type|d("default") in ["divert"])
+  with_dict: '{{ apache__combined_snippets }}'
+
+- name: Disable configuration snippets
+  file:
+    path: '{{ apache__config_path + "/conf-enabled/" + item.key + ".conf" }}'
+    src: '../conf-available/{{ item.key }}.conf'
+    force: '{{ ansible_check_mode|d() | bool }}'
+    state: 'absent'
+  when: (not (item.value.enabled|d(True)
+              if (item.value is mapping)
+              else item.value|d(True))) or
+        (item.value.state|d("present") == "absent")
+  with_dict: '{{ apache__combined_snippets }}'
+  notify: [ 'Test apache and reload' ]
+
 # Manage Apache modules [[[1
 - name: Get list of available modules
   find:
@@ -26,26 +59,7 @@
 
 - include: apache_module_state.yml
 
-# Manage Apache configuration snippets [[[1
-- name: Divert conf-available configuration
-  command: dpkg-divert --quiet --local
-             --divert {{ ((item.value.divert | d(apache__config_path + "/conf-available/" + (item.value.divert_filename|d(item.key)) + ".conf"))
-                         + item.value.divert_suffix|d(".dpkg-divert")) | quote }}
-             --rename {{ (apache__config_path + "/conf-available/" + item.key + ".conf") | quote }}
-  args:
-    creates: '{{ ( item.value.divert | d(apache__config_path + "/conf-available/" + (item.value.divert_filename|d(item.key)) + ".conf"))
-                 + item.value.divert_suffix|d(".dpkg-divert") }}'
-  when: (item.value.type|d("default") in ["divert"])
-  with_dict: '{{ apache__combined_snippets }}'
-
-- name: Remove conf-available snippets
-  file:
-    path: '{{ apache__config_path + "/conf-available/" + item.key + ".conf" }}'
-    state: 'absent'
-  when: (item.value.state|d("present") == "absent")
-  with_dict: '{{ apache__combined_snippets }}'
-  tags: [ 'role::apache:vhosts' ]
-
+# Enable Apache configuration snippets [[[1
 - name: Create conf-available snippets
   template:
     src: 'etc/apache2/conf-available/{{ "raw" if (item.value.type|d("default") in ["divert", "raw"] and item.value.raw|d()) else item.key }}.conf.j2'
@@ -58,19 +72,20 @@
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
 
-- name: Enable/disable configuration snippets
+- name: Enable configuration snippets
   file:
     path: '{{ apache__config_path + "/conf-enabled/" + item.key + ".conf" }}'
     src: '../conf-available/{{ item.key }}.conf'
     force: '{{ ansible_check_mode|d() | bool }}'
-    state: '{{ (((item.value.enabled|d(True)
-                  if (item.value is mapping)
-                  else item.value|d(True)))
-                 if (item.value.state|d("present") != "absent")
-                 else False) | bool | ternary("link", "absent") }}'
-  when: (item.value.type|d("default") not in ["divert"])
+    state: 'present'
+  when: (item.value.type|d("default") not in ["divert"]) and
+        ((item.value.enabled|d(True)
+          if (item.value is mapping)
+          else item.value|d(True)) or
+         (item.value.state|d("present") != "absent"))
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
+
 
 # Manage Apache virtual hosts [[[1
 - name: Divert sites-available configuration


### PR DESCRIPTION
The `apache2_module` Ansible module used for activating/deactivating Apache 2 modules expects a valid server configuration when it's running. However, it might happen, that a 3rd party mechanism installs a snippet which requires some modules not yet available before running the module tasks. This would result in an error such as:

```
TASK [debops.apache : Enable/disable Apache modules] ***************************

failed: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] (item={'key': u'status', 'value': {u'config': u'<Location /server-status>\n    # Revoke default permissions granted in `/etc/apache2/mods-available/status.conf`.\n    Require all denied\n</Location>\n', u'enabled': False}}) => {
    "failed": true,
    "item": {
        "key": "status",
        "value": {
            "config": "<Location /server-status>\n    # Revoke default permissions granted in `/etc/apache2/mods-available/status.conf`.\n    Require all denied\n</Location>\n",
            "enabled": false
        }
    },
    "msg": "Error executing /usr/sbin/apache2ctl: AH00526: Syntax error on line 15 of /omd/sites/debops/etc/apache/mode.conf:\nInvalid command 'RequestHeader', perhaps misspelled or defined by a module not included in the server configuration\n"
}
failed: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] (item={'key': u'ssl', 'value': {u'enabled': True}}) => {
    "failed": true,
    "item": {
        "key": "ssl",
        "value": {
            "enabled": true
        }
    },
    "msg": "Error executing /usr/sbin/apache2ctl: AH00526: Syntax error on line 15 of /omd/sites/debops/etc/apache/mode.conf:\nInvalid command 'RequestHeader', perhaps misspelled or defined by a module not included in the server configuration\n"
}
failed: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] (item={'key': u'alias', 'value': True}) => {
    "failed": true,
    "item": {
        "key": "alias",
        "value": true
    },
    "msg": "Error executing /usr/sbin/apache2ctl: AH00526: Syntax error on line 15 of /omd/sites/debops/etc/apache/mode.conf:\nInvalid command 'RequestHeader', perhaps misspelled or defined by a module not included in the server configuration\n"
}
skipping: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] => (item={'key': u'rewrite', 'value': {u'enabled': u'__omit_place_holder__2bea8924e63222be5e172335bca83136e33ad91e'}}) 
failed: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] (item={'key': u'socache_shmcb', 'value': {u'enabled': True}}) => {
    "failed": true,
    "item": {
        "key": "socache_shmcb",
        "value": {
            "enabled": true
        }
    },
    "msg": "Error executing /usr/sbin/apache2ctl: AH00526: Syntax error on line 15 of /omd/sites/debops/etc/apache/mode.conf:\nInvalid command 'RequestHeader', perhaps misspelled or defined by a module not included in the server configuration\n"
}
skipping: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] => (item={'key': u'authz_host', 'value': {u'enabled': u'__omit_place_holder__2bea8924e63222be5e172335bca83136e33ad91e'}}) 
skipping: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] => (item={'key': u'security2', 'value': {u'enabled': False}}) 
failed: [testing-gce-b3d41b03-024b-44de-a23b-d4446e41dc8c] (item={'key': u'headers', 'value': True}) => {
    "failed": true,
    "item": {
        "key": "headers",
        "value": true
    },
    "msg": "Error executing /usr/sbin/apache2ctl: AH00526: Syntax error on line 15 of /omd/sites/debops/etc/apache/mode.conf:\nInvalid command 'RequestHeader', perhaps misspelled or defined by a module not included in the server configuration\n"
}
```

However, I must admit that in my case, I manually patch the Apache configuration shipped by the Check_MK package which triggers this error. I guess if a .deb package is shipping such an "invalid" configuration this would be considered a bug.

Maybe there are some other conditions which would make those changes useful. Otherwise it'll be a reference if someone ever has this issue and needs a quick fix. Feel free to close it if you don't see fit.

I'm using this patchset until I figured out a way to fix the HTTPS issues in Check_MK in a cleaner way. 