### PR TITLE
Make sure SSL is disabled if requested

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,3 +92,6 @@ Fixed
 - Fix an issue where ``mod_rewrite`` could not be activated after initial role
   deployment when existing configuration contained unwrapped rewrite rules.
   [drybjed_]
+
+- Don't define HTTPS redirects for vhosts and completely disable ``mod_ssl``
+  if :envvar:`apache__https_enabled` is set to ``False``. [ganto_]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -471,7 +471,7 @@ apache__https_enabled: '{{ ansible_local|d() and ansible_local.pki|d() and
 #
 # This defines the default for each vhost's ``redirect_to_https`` variable.
 # Defaults to ``True``.
-apache__redirect_to_https: True
+apache__redirect_to_https: '{{ True if apache__https_enabled else False }}'
 
                                                                    # ]]]
 # PKI [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -471,7 +471,7 @@ apache__https_enabled: '{{ ansible_local|d() and ansible_local.pki|d() and
 #
 # This defines the default for each vhost's ``redirect_to_https`` variable.
 # Defaults to ``True``.
-apache__redirect_to_https: '{{ True if apache__https_enabled else False }}'
+apache__redirect_to_https: '{{ apache__https_enabled|bool }}'
 
                                                                    # ]]]
 # PKI [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -314,7 +314,7 @@ apache__role_modules:
   'headers': True
   'alias': True
   'ssl':
-    enabled: '{{ True if (apache__https_listen) else False }}'
+    enabled: '{{ True if (apache__https_listen and apache__https_enabled) else False }}'
   'security2':
     enabled: '{{ apache__security_module_enabled|bool }}'
   'status':


### PR DESCRIPTION
Fix configuration when `apache__https_enabled: False`. 

According to the documentation this setting should completely disable HTTPS support:

> Should HTTPS be enabled by loading the required modules and creating HTTPS virtual hosts? 

However, currently there will still be 301 redirects to https:// URLs in the vhost definition and also `mod_ssl` is still loaded. This PR will fix this.