### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,4 +96,4 @@ Fixed
 - Don't define HTTPS redirects for vhosts and completely disable ``mod_ssl``
   if :envvar:`apache__https_enabled` is set to ``False``. [ganto_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,4 +96,5 @@ Fixed
 - Don't define HTTPS redirects for vhosts and completely disable ``mod_ssl``
   if :envvar:`apache__https_enabled` is set to ``False``. [ganto_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,3 +95,5 @@ Fixed
 
 - Don't define HTTPS redirects for vhosts and completely disable ``mod_ssl``
   if :envvar:`apache__https_enabled` is set to ``False``. [ganto_]
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   author: 'Robin Schneider'
   description: 'Manage and configure the Apache HTTP Server'
   license: 'GPL-3.0'
-  min_ansible_version: '2.1.5'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,7 +139,7 @@
 - name: Detect if the rewrite module has been used in the active configuration
   shell: grep --ignore-case '^\s*RewriteEngine On' {{ apache__config_path | quote }}/sites-enabled/* {{ apache__config_path | quote }}/conf-enabled/*
   register: apache__register_mod_rewrite_used
-  always_run: True
+  check_mode: no
   failed_when: apache__register_mod_rewrite_used.rc not in [ 0, 1 ]
   changed_when: False
   when: apache__register_mod_rewrite_used is undefined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,7 +139,7 @@
 - name: Detect if the rewrite module has been used in the active configuration
   shell: grep --ignore-case '^\s*RewriteEngine On' {{ apache__config_path | quote }}/sites-enabled/* {{ apache__config_path | quote }}/conf-enabled/*
   register: apache__register_mod_rewrite_used
-  check_mode: no
+  check_mode: False
   failed_when: apache__register_mod_rewrite_used.rc not in [ 0, 1 ]
   changed_when: False
   when: apache__register_mod_rewrite_used is undefined


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.